### PR TITLE
[Fix warnings #4] Dataframe colum should be 1d array instead

### DIFF
--- a/.github/workflows/brise_ci.yml
+++ b/.github/workflows/brise_ci.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ master, develop ]
   pull_request:
-    branches: [ master, develov ]
+    branches: [ master, develop ]
 
 jobs:
   docker-build:

--- a/.github/workflows/brise_ci.yml
+++ b/.github/workflows/brise_ci.yml
@@ -5,9 +5,9 @@ name: BRISE-CI
 
 on:
   push:
-    branches: [ master, dev ]
+    branches: [ master, develop ]
   pull_request:
-    branches: [ master, dev ]
+    branches: [ master, develov ]
 
 jobs:
   docker-build:

--- a/main_node/configuration_selection/model/surrogate/sklearn_wrapper.py
+++ b/main_node/configuration_selection/model/surrogate/sklearn_wrapper.py
@@ -28,7 +28,12 @@ class SklearnWrapper(Surrogate):
         transformed_features = self._transform_configuration(features)
         transformed_labels = self._transform_values(labels)
 
-        self.surrogate_instance.fit(transformed_features, transformed_labels)
+        # force labels to be 1d-array, otherwise pd.dataframe is 2d object with one column
+        y = transformed_labels
+        if isinstance(transformed_labels, pd.DataFrame) and transformed_labels.shape[1] == 1:
+            y = transformed_labels.iloc[:, 0].values.ravel()
+
+        self.surrogate_instance.fit(transformed_features, y)
         return True
 
     def predict(self, cfg: pd.Series, transform: bool = True) -> pd.DataFrame:

--- a/main_node/configuration_selection/model/surrogate/sklearn_wrapper.py
+++ b/main_node/configuration_selection/model/surrogate/sklearn_wrapper.py
@@ -27,9 +27,8 @@ class SklearnWrapper(Surrogate):
 
         transformed_features = self._transform_configuration(features)
         transformed_labels = self._transform_values(labels)
-        y = transformed_labels
 
-        self.surrogate_instance.fit(transformed_features, y)
+        self.surrogate_instance.fit(transformed_features, transformed_labels)
         return True
 
     def predict(self, cfg: pd.Series, transform: bool = True) -> pd.DataFrame:

--- a/main_node/configuration_selection/model/surrogate/sklearn_wrapper.py
+++ b/main_node/configuration_selection/model/surrogate/sklearn_wrapper.py
@@ -27,11 +27,7 @@ class SklearnWrapper(Surrogate):
 
         transformed_features = self._transform_configuration(features)
         transformed_labels = self._transform_values(labels)
-
-        # force labels to be 1d-array, otherwise pd.dataframe is 2d object with one column
         y = transformed_labels
-        if isinstance(transformed_labels, pd.DataFrame) and transformed_labels.shape[1] == 1:
-            y = transformed_labels.iloc[:, 0].values.ravel()
 
         self.surrogate_instance.fit(transformed_features, y)
         return True
@@ -53,3 +49,12 @@ class SklearnWrapper(Surrogate):
             result = pd.DataFrame(predicted, columns=["Y"])
 
         return result
+
+    def _transform_values(self, labels: pd.DataFrame) -> pd.DataFrame:
+        # flatten labels to be 1d-array
+        transformed_labels = super()._transform_values(labels)
+        
+        if isinstance(transformed_labels, pd.DataFrame) and transformed_labels.shape[1] == 1:
+            return transformed_labels.iloc[:, 0].values.ravel()
+            
+        return transformed_labels


### PR DESCRIPTION
surrogate expects 1D array, convert column to 1d array

avoid some dataconversionwanring for multidimensional arrays in sklearn_wrapper.py (DataConversionWarning: A column-vector y was passed when a 1d array was expected. Please change the shape of y to (n_samples, ), for example using ravel(). y = column_or_1d(y, warn=True