### PR TITLE
Fix Badge CI Workflow

### DIFF
--- a/.github/workflows/badge.yml
+++ b/.github/workflows/badge.yml
@@ -1,14 +1,18 @@
 name: Code Coverage Badge
 
 on:
-  push:
-    branches: [develop]
+  workflow_run:
+    workflows: ["BRISE-CI"]
+    types:
+      - completed
 
 permissions:
   contents: write
 
 jobs:
   if_merged:
+    # only run if completed percentage upload workflow was successful and the branch is develop
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'develop' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -16,11 +20,19 @@ jobs:
         with:
           persist-credentials: true
 
+      - name: Download Coverage Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: code-coverage-report
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Extract coverage %
         shell: bash -l {0}
         run: |
-          PERCENT=$(( RANDOM % 101 ))
-          echo "coverage=${PERCENT}"
+          LINE_RATE=$(grep -oP 'line-rate="\K[0-9]+(\.[0-9]+)?' coverage.xml | head -n1 || echo 0)
+          PERCENT=$(awk "BEGIN{printf \"%d\", ($LINE_RATE*100)+0.5}")
+          echo "Extracted coverage is: ${PERCENT}%"
           mkdir -p badge-data
 
           # Choose color based on percentage

--- a/.github/workflows/badge.yml
+++ b/.github/workflows/badge.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          ref: ${{ github.event.workflow_run.head_branch }}
           persist-credentials: true
 
       # Download coverage.xml from previous workflow
@@ -35,7 +36,7 @@ jobs:
         run: |
           cd main_node
           # fail if file doesnt exist
-          test -f main_node/coverage.xml
+          test -f coverage.xml
 
           LINE_RATE=$(grep -oP 'line-rate="\K[0-9]+(\.[0-9]+)?' coverage.xml | head -n1 || echo 0)
           PERCENT=$(awk "BEGIN{printf \"%d\", ($LINE_RATE*100)+0.5}")
@@ -72,7 +73,6 @@ jobs:
       - name: Commit badge data
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit_message: "Update coverage badge"
+          commit_message: "Update coverage badge [skip CI]"
           file_pattern: badge-data/coverage.svg
-          branch: develop
+          branch: ${{ github.event.workflow_run.head_branch }}

--- a/.github/workflows/badge.yml
+++ b/.github/workflows/badge.yml
@@ -1,0 +1,60 @@
+name: Update Coverage Badge
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  update-badge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+      actions: read
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-percentage
+          path: .
+
+      - name: Extract coverage % - TODO: remove color process here
+        id: coverage
+        run: |
+          LINE_RATE=$(grep -oP 'line-rate="\K[0-9]+(\.[0-9]+)?' main_node/coverage.xml | head -n1 || echo 0)
+          PERCENT=$(awk "BEGIN{printf \"%d\", ($LINE_RATE*100)+0.5}")
+          echo "coverage=${PERCENT}" >> $GITHUB_OUTPUT
+
+          # Choose color based on percentage
+          if (( PERCENT >= 90 )); then
+              COLOR=brightgreen
+          elif (( PERCENT >= 80 )); then
+              COLOR=green
+          elif (( PERCENT >= 70 )); then
+              COLOR=yellowgreen
+          elif (( PERCENT >= 60 )); then
+              COLOR=yellow
+          elif (( PERCENT >= 50 )); then
+              COLOR=orange
+          else
+              COLOR=red
+          fi
+
+          # Create URL with percentage
+          url="https://img.shields.io/badge/Code%20Coverage-${PERCENT}%25-${COLOR}?style=flat"
+          curl -sSL --fail "$url" -o badge-data/coverage.svg
+
+      - name: Commit and push badge
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions@github.com"
+          git add badge-data/coverage.svg
+          git commit -m "Update coverage badge [skip ci]" || echo "No changes to commit"
+          git push origin HEAD:${{ github.event.pull_request.head.ref }} --force

--- a/.github/workflows/badge.yml
+++ b/.github/workflows/badge.yml
@@ -1,38 +1,35 @@
-name: Update Coverage Badge
+name: Code Coverage Badge
 
 on:
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+  push:
+    branches: [develop]
+
+permissions:
+  contents: write
 
 jobs:
-  update-badge:
+  if_merged:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: read
-      actions: read
-
     steps:
-      - name: Checkout PR branch
-        uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
+          persist-credentials: true
 
-      - name: Download coverage artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: coverage-percentage
-          path: .
-
-      - name: Extract coverage  TODO remove color process here
-        id: coverage
+      - name: Extract coverage %
+        shell: bash -l {0}
         run: |
-          LINE_RATE=$(grep -oP 'line-rate="\K[0-9]+(\.[0-9]+)?' main_node/coverage.xml | head -n1 || echo 0)
-          PERCENT=$(awk "BEGIN{printf \"%d\", ($LINE_RATE*100)+0.5}")
-          echo "coverage=${PERCENT}" >> $GITHUB_OUTPUT
+          PERCENT=$(( RANDOM % 101 ))
+          echo "coverage=${PERCENT}"
+          mkdir -p badge-data
 
           # Choose color based on percentage
+          # 90-100% brightgreen
+          # 80-89% green
+          # 70-79% yellowgreen
+          # 60-69% yellow
+          # 50-59%  orange
+          # <50% red
           if (( PERCENT >= 90 )); then
               COLOR=brightgreen
           elif (( PERCENT >= 80 )); then
@@ -47,14 +44,16 @@ jobs:
               COLOR=red
           fi
 
-          # Create URL with percentage
+          # create url with percentage
+          n=$(($PERCENT+0))
           url="https://img.shields.io/badge/Code%20Coverage-${PERCENT}%25-${COLOR}?style=flat"
           curl -sSL --fail "$url" -o badge-data/coverage.svg
+      # Commit updated badge svg
+      - name: Commit badge data
+        uses: stefanzweifel/git-auto-commit-action@v4
 
-      - name: Commit and push badge
-        run: |
-          git config --global user.name "github-actions"
-          git config --global user.email "github-actions@github.com"
-          git add badge-data/coverage.svg
-          git commit -m "Update coverage badge [skip ci]" || echo "No changes to commit"
-          git push origin HEAD:${{ github.event.pull_request.head.ref }} --force
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit_message: "Update coverage badge"
+          file_pattern: badge-data/coverage.svg
+          branch: main

--- a/.github/workflows/badge.yml
+++ b/.github/workflows/badge.yml
@@ -13,6 +13,7 @@ jobs:
   if_merged:
     # only run if completed percentage upload workflow was successful and the branch is develop
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'develop' }}
+    
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -20,6 +21,7 @@ jobs:
         with:
           persist-credentials: true
 
+      # Download coverage.xml from previous workflow
       - name: Download Coverage Artifact
         uses: actions/download-artifact@v4
         with:
@@ -27,9 +29,11 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Extract coverage rom main_noide/coverage.xml and generate badge
       - name: Extract coverage %
         shell: bash -l {0}
         run: |
+          cd main_node
           LINE_RATE=$(grep -oP 'line-rate="\K[0-9]+(\.[0-9]+)?' coverage.xml | head -n1 || echo 0)
           PERCENT=$(awk "BEGIN{printf \"%d\", ($LINE_RATE*100)+0.5}")
           echo "Extracted coverage is: ${PERCENT}%"
@@ -56,16 +60,16 @@ jobs:
               COLOR=red
           fi
 
-          # create url with percentage
+          # create badge url with percentage
           n=$(($PERCENT+0))
           url="https://img.shields.io/badge/Code%20Coverage-${PERCENT}%25-${COLOR}?style=flat"
           curl -sSL --fail "$url" -o badge-data/coverage.svg
-      # Commit updated badge svg
+      
+          # Commit updated badge svg
       - name: Commit badge data
         uses: stefanzweifel/git-auto-commit-action@v4
-
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit_message: "Update coverage badge"
           file_pattern: badge-data/coverage.svg
-          branch: main
+          branch: develop

--- a/.github/workflows/badge.yml
+++ b/.github/workflows/badge.yml
@@ -25,7 +25,7 @@ jobs:
           name: coverage-percentage
           path: .
 
-      - name: Extract coverage % - TODO: remove color process here
+      - name: Extract coverage  TODO remove color process here
         id: coverage
         run: |
           LINE_RATE=$(grep -oP 'line-rate="\K[0-9]+(\.[0-9]+)?' main_node/coverage.xml | head -n1 || echo 0)

--- a/.github/workflows/badge.yml
+++ b/.github/workflows/badge.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   if_merged:
     # only run if completed percentage upload workflow was successful and the branch is develop
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'develop' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'develop' || github.event.workflow_run.head_branch == 'master') }}
     
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/badge.yml
+++ b/.github/workflows/badge.yml
@@ -34,6 +34,9 @@ jobs:
         shell: bash -l {0}
         run: |
           cd main_node
+          # fail if file doesnt exist
+          test -f main_node/coverage.xml
+
           LINE_RATE=$(grep -oP 'line-rate="\K[0-9]+(\.[0-9]+)?' coverage.xml | head -n1 || echo 0)
           PERCENT=$(awk "BEGIN{printf \"%d\", ($LINE_RATE*100)+0.5}")
           echo "Extracted coverage is: ${PERCENT}%"

--- a/.github/workflows/brise_ci.yml
+++ b/.github/workflows/brise_ci.yml
@@ -65,7 +65,8 @@ jobs:
           cd main_node
           pytest --cov=. --cov-report=xml:coverage.xml --cov-report=term || TEST_EXIT_CODE=$?
           if [ -n "${TEST_EXIT_CODE:-}" ]; then exit $TEST_EXIT_CODE; fi
-      # Fetch coverage badge svg
+      
+      # (Optional) Print coverage percentage
       - name: Extract coverage %
         shell: bash -el {0}
         run: |
@@ -73,6 +74,8 @@ jobs:
           LINE_RATE=$(grep -oP 'line-rate="\K[0-9]+(\.[0-9]+)?' coverage.xml | head -n1 || echo 0)
           PERCENT=$(awk "BEGIN{printf \"%d\", ($LINE_RATE*100)+0.5}")
           echo "coverage=${PERCENT}"
+
+      # Save coverage report as artifact
       - name: Upload Coverage XML
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/brise_ci.yml
+++ b/.github/workflows/brise_ci.yml
@@ -79,5 +79,5 @@ jobs:
       - name: Upload Coverage XML
         uses: actions/upload-artifact@v4
         with:
-          name: code-coverage-report
+          name: coverage
           path: main_node/coverage.xml

--- a/.github/workflows/brise_ci.yml
+++ b/.github/workflows/brise_ci.yml
@@ -102,8 +102,10 @@ jobs:
           url="https://img.shields.io/badge/Code%20Coverage-${PERCENT}%25-${COLOR}?style=flat"
           curl -sSL --fail "$url" -o badge-data/coverage.svg
       # Commit updated badge svg
-      - name: Commit badge data
-        uses: stefanzweifel/git-auto-commit-action@v4
+      - name: Upload coverage percentage
+        uses: actions/upload-artifact@v4
         with:
-          commit_message: "Update coverage badge"
-          file_pattern: badge-data/coverage.svg
+          name: coverage-percentage
+          path: |
+            main_node/coverage.xml
+            badge-data/coverage.svg

--- a/.github/workflows/brise_ci.yml
+++ b/.github/workflows/brise_ci.yml
@@ -73,39 +73,3 @@ jobs:
           LINE_RATE=$(grep -oP 'line-rate="\K[0-9]+(\.[0-9]+)?' coverage.xml | head -n1 || echo 0)
           PERCENT=$(awk "BEGIN{printf \"%d\", ($LINE_RATE*100)+0.5}")
           echo "coverage=${PERCENT}"
-          cd ..
-          mkdir -p badge-data
-  
-          # Choose color based on percentage
-          # 90-100% brightgreen
-          # 80-89% green
-          # 70-79% yellowgreen
-          # 60-69% yellow
-          # 50-59%  orange
-          # <50% red
-          if (( PERCENT >= 90 )); then
-              COLOR=brightgreen
-          elif (( PERCENT >= 80 )); then
-              COLOR=green
-          elif (( PERCENT >= 70 )); then
-              COLOR=yellowgreen
-          elif (( PERCENT >= 60 )); then
-              COLOR=yellow
-          elif (( PERCENT >= 50 )); then
-              COLOR=orange
-          else
-              COLOR=red
-          fi
-  
-          # create url with percentage
-          n=$(($PERCENT+0))
-          url="https://img.shields.io/badge/Code%20Coverage-${PERCENT}%25-${COLOR}?style=flat"
-          curl -sSL --fail "$url" -o badge-data/coverage.svg
-      # Commit updated badge svg
-      - name: Upload coverage percentage
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-percentage
-          path: |
-            main_node/coverage.xml
-            badge-data/coverage.svg

--- a/.github/workflows/brise_ci.yml
+++ b/.github/workflows/brise_ci.yml
@@ -73,3 +73,8 @@ jobs:
           LINE_RATE=$(grep -oP 'line-rate="\K[0-9]+(\.[0-9]+)?' coverage.xml | head -n1 || echo 0)
           PERCENT=$(awk "BEGIN{printf \"%d\", ($LINE_RATE*100)+0.5}")
           echo "coverage=${PERCENT}"
+      - name: Upload Coverage XML
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage-report
+          path: main_node/coverage.xml


### PR DESCRIPTION
Split up workflow in:
-  BRISE-CI which builds and tests, then uploads coverage.xml as artifact
- badge CI which extracts the codevoerage form the artifact and commits the updated badge


-> pls squash commits on merge ^^"