### PR TITLE
Fix scalar acceptable error thresholds

### DIFF
--- a/main_node/Resources/tests/test_acceptable_error_based.py
+++ b/main_node/Resources/tests/test_acceptable_error_based.py
@@ -1,0 +1,34 @@
+from repeater.acceptable_error_based import AcceptableErrorBasedType
+
+
+class FakeDatabase:
+    def get_last_record_by_experiment_id(self, collection_name, experiment_id):
+        return {"Current_solution": {"Results": {"obj_1": 100.0, "obj_2": 100.0}}}
+
+
+class FakeConfiguration:
+    results = {"obj_1": 100.0, "obj_2": 100.0}
+
+    def get_tasks(self):
+        return [object(), object(), object()]
+
+    def get_standard_deviation(self):
+        return [0.0, 0.0]
+
+
+def test_scalar_base_acceptable_error_is_used_for_each_objective():
+    repeater = AcceptableErrorBasedType.__new__(AcceptableErrorBasedType)
+    repeater.objectives = {
+        "obj_1": {"Minimization": True},
+        "obj_2": {"Minimization": True},
+    }
+    repeater.objectives_minimization = [True, True]
+    repeater.min_tasks_per_configuration = 2
+    repeater.max_tasks_per_configuration = 7
+    repeater.base_acceptable_errors = 5.0
+    repeater.confidence_levels = 0.95
+    repeater.is_experiment_aware = False
+    repeater.experiment_id = "test"
+    repeater.database = FakeDatabase()
+
+    assert repeater.evaluate(FakeConfiguration()) == 0

--- a/main_node/repeater/acceptable_error_based.py
+++ b/main_node/repeater/acceptable_error_based.py
@@ -151,8 +151,10 @@ class AcceptableErrorBasedType(Repeater):
 
             else:
                 # Or we don't adapt thresholds
-                for acceptable_error in self.base_acceptable_errors:
-                    thresholds.append(acceptable_error)
+                try:
+                    thresholds.extend(self.base_acceptable_errors)
+                except TypeError:
+                    thresholds.extend([self.base_acceptable_errors] * len(self.objectives))
 
             # Simple implementation of possible multi-dim Repeater decision-making:
             # If any of resulting dimensions are not accurate - just terminate.


### PR DESCRIPTION
## Summary
- treat scalar `BaseAcceptableError` values as the threshold for each objective in non experiment-aware repetition management
- preserve the old iterable threshold behavior for list-like values
- add a focused regression test for the `float object is not iterable` path

Closes #64

## Tests
- `uv run --python 3.12 --with pytest --with scipy --with pymongo --with pandas pytest Resources/tests/test_acceptable_error_based.py -q`
- `uv run --python 3.12 --with flake8 flake8 . --config tox.ini --select=E9,F63,F7,F82 --show-source --statistics`
- `git diff --check`

## Notes
- I also tried `uv run --python 3.12 --with pytest --with scipy --with pymongo --with pandas --with scikit-learn --with pyyaml --with pika pytest Resources/tests/test_input.py::TestInput::test_3 -q`. It gets past imports but then fails during full `Experiment` setup because the local run does not have the CI MongoDB service/environment variables (`BRISE_DATABASE_HOST`, etc.). The new unit test isolates the repeater branch from that external service setup.

AI assistance was used under my direction.