### PR TITLE
Fix wanrings #5 - Divide by Zero patrt 2: Silence warning

### DIFF
--- a/main_node/configuration_selection/model/surrogate/tree_parzen_estimator.py
+++ b/main_node/configuration_selection/model/surrogate/tree_parzen_estimator.py
@@ -28,6 +28,8 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import warnings
+
 import pandas as pd
 import numpy as np
 import statsmodels.api as sm
@@ -114,8 +116,14 @@ class TreeParzenEstimator(Surrogate):
         # 'normal_reference' - default, quick, rule of thumb
         bw_estimation = 'normal_reference'
 
-        good_kde = sm.nonparametric.KDEMultivariate(data=t_features_good, var_type=self.kde_vartypes, bw=bw_estimation)
-        bad_kde = sm.nonparametric.KDEMultivariate(data=t_features_bad, var_type=self.kde_vartypes, bw=bw_estimation)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", 
+                message="divide by zero encountered in divide", 
+                category=RuntimeWarning
+            )
+            good_kde = sm.nonparametric.KDEMultivariate(data=t_features_good, var_type=self.kde_vartypes, bw=bw_estimation)
+            bad_kde = sm.nonparametric.KDEMultivariate(data=t_features_bad, var_type=self.kde_vartypes, bw=bw_estimation)
 
         good_kde.bw = np.clip(good_kde.bw, self.min_bandwidth, None)
         bad_kde.bw = np.clip(bad_kde.bw, self.min_bandwidth, None)


### PR DESCRIPTION
fix divide by zero Part2

    configuration_selection/tests/test_configuration_selection.py: 7680 warnings
    /usr/share/miniconda3/envs/brise-260/lib/python3.12/site-packages/statsmodels/nonparametric/kernels.py:62: RuntimeWarning: divide by zero encountered in divide
    kernel_value = np.ones(Xi.size) * h / (num_levels - 1)
 -> silence warning 



alternativly filter out hyperparamters with only one categorical colum so `num_levels - 1` doesnt become zero