### PR TITLE
Feature/default configuration handling

### DIFF
--- a/main_node/Resources/tests/waffle_models/base.wfl
+++ b/main_node/Resources/tests/waffle_models/base.wfl
@@ -14,7 +14,14 @@ abstract Category {
 abstract CategoricalHyperparameter : Hyperparameter {
   Categories -> predefined
   Default -> string
-  [Default in Categories]
+
+  // DefaultConfHandler selected
+
+
+  // No DefaultConfHandler selected
+  [if fcard.DefaultConfigurationHandler == 0 then self.Default = 1]
+  [if self.Default then Default in Categories]
+  
   [Categories = (filter childs.self where Type == "Category")]
 }
 
@@ -32,8 +39,18 @@ abstract FloatHyperparameter: NumericHyperparameter {
   Lower -> float
   Upper -> float
   Default -> float
-  [Default >= Lower]
-  [Default <= Upper]
+  
+  // DefaultConfHandler selected
+  [if fcard.DefaultConfigurationHandler == 1 then self.Default = 0]
+  [if fcard.DefaultConfigurationHandler == 1 then Lower = 0]
+  [if fcard.DefaultConfigurationHandler == 1 then Upper = 1]
+
+  // No DefaultConfHandler selected
+  [if fcard.DefaultConfigurationHandler == 0 then Lower < Upper]
+  [if fcard.DefaultConfigurationHandler == 0 then self.Default = 1]
+  [if self.Default then Default >= Lower]
+  [if self.Default then Default <= Upper]
+
   [Type = "FloatHyperparameter"]
   [fcard.StopCondition.Instance.AdaptiveSC = 0]
 }
@@ -41,8 +58,18 @@ abstract IntegerHyperparameter: NumericHyperparameter {
   Lower -> integer
   Upper -> integer
   Default -> integer
-  [Default >= Lower]
-  [Default <= Upper]
+  
+  // DefaultConfHandler selected
+  [if fcard.DefaultConfigurationHandler == 1 then self.Default = 0]
+  [if fcard.DefaultConfigurationHandler == 1 then Lower = 0]
+  [if fcard.DefaultConfigurationHandler == 1 then Upper = 1]
+  
+  // No DefaultConfHandler selected
+  [if fcard.DefaultConfigurationHandler == 0 then Lower < Upper]
+  [if fcard.DefaultConfigurationHandler == 0 then self.Default = 1]
+  [if self.Default then Default >= Lower]
+  [if self.Default then Default <= Upper]
+
   [Type = "IntegerHyperparameter"]
 }
 

--- a/main_node/Resources/tests/waffle_models/base.wfl
+++ b/main_node/Resources/tests/waffle_models/base.wfl
@@ -17,7 +17,6 @@ abstract CategoricalHyperparameter : Hyperparameter {
 
   // DefaultConfHandler selected
 
-
   // No DefaultConfHandler selected
   [if fcard.DefaultConfigurationHandler == 0 then self.Default = 1]
   [if self.Default then Default in Categories]
@@ -54,6 +53,7 @@ abstract FloatHyperparameter: NumericHyperparameter {
   [Type = "FloatHyperparameter"]
   [fcard.StopCondition.Instance.AdaptiveSC = 0]
 }
+
 abstract IntegerHyperparameter: NumericHyperparameter {
   Lower -> integer
   Upper -> integer

--- a/main_node/Resources/tests/waffle_models/base.wfl
+++ b/main_node/Resources/tests/waffle_models/base.wfl
@@ -15,12 +15,8 @@ abstract CategoricalHyperparameter : Hyperparameter {
   Categories -> predefined
   Default -> string
 
-  // DefaultConfHandler selected
-
   // No DefaultConfHandler selected
-  [if fcard.DefaultConfigurationHandler == 0 then self.Default = 1]
-  [if self.Default then Default in Categories]
-  
+  [if fcard.DefaultConfigurationHandler == 0 and self.Default then Default in Categories]
   [Categories = (filter childs.self where Type == "Category")]
 }
 
@@ -38,7 +34,7 @@ abstract FloatHyperparameter: NumericHyperparameter {
   Lower -> float
   Upper -> float
   Default -> float
-  
+
   // DefaultConfHandler selected
   [if fcard.DefaultConfigurationHandler == 1 then self.Default = 0]
   [if fcard.DefaultConfigurationHandler == 1 then Lower = 0]
@@ -58,12 +54,12 @@ abstract IntegerHyperparameter: NumericHyperparameter {
   Lower -> integer
   Upper -> integer
   Default -> integer
-  
+
   // DefaultConfHandler selected
   [if fcard.DefaultConfigurationHandler == 1 then self.Default = 0]
   [if fcard.DefaultConfigurationHandler == 1 then Lower = 0]
   [if fcard.DefaultConfigurationHandler == 1 then Upper = 1]
-  
+
   // No DefaultConfHandler selected
   [if fcard.DefaultConfigurationHandler == 0 then Lower < Upper]
   [if fcard.DefaultConfigurationHandler == 0 then self.Default = 1]


### PR DESCRIPTION
Dont let user choose upper/lower bounds on hyperparamter when DefaultConfigurationHandler is seelcted, since it overwrites them anyways

Minimal example: [testWaffle.txt](https://github.com/user-attachments/files/29857131/testWaffle.txt)


(pls squash on merge)
